### PR TITLE
Fix: volume flag for scripts did not use PWD

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,8 @@
-docker run -d -v /home/$USER/scans:/scans -v script:/opt/brother/scanner/brscan-skey/script/ -e "NAME=Scanner" -e "MODEL=MFC-L2700DW" -e "IPADDRESS=192.168.1.123" --net=host brother
+docker run \
+    -d \
+    -v /home/$USER/scans:/scans \
+    -v $PWD/script:/opt/brother/scanner/brscan-skey/script/ \
+    -e NAME="Scanner" \
+    -e MODEL="MFC-L2700DW" \
+    -e IPADDRESS="10.0.0.1" \
+    --net=host brother-scanner


### PR DESCRIPTION
This commit fixes the volume flag for the scripts dir.  Previously it did not use PWD in the bind mount, which caused it to mount in the docker volume default location, not in the local git repo on disk.